### PR TITLE
Allow LiteDBContext customization by injecting its interface.

### DIFF
--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB.Demo/Startup.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB.Demo/Startup.cs
@@ -22,7 +22,7 @@ namespace AspNetCore.Identity.LiteDB.Demo
         public void ConfigureServices(IServiceCollection services)
         {
             // Add LiteDB Dependency
-            services.AddSingleton<LiteDbContext>();
+            services.AddSingleton<ILiteDbContext, LiteDbContext>();
 
             services.AddIdentity<ApplicationUser, AspNetCore.Identity.LiteDB.IdentityRole>(options =>
                 {

--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/Data/ILiteDbContext.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/Data/ILiteDbContext.cs
@@ -1,0 +1,9 @@
+using LiteDB;
+
+namespace AspNetCore.Identity.LiteDB.Data
+{
+    public interface ILiteDbContext
+    {
+        LiteDatabase LiteDatabase { get; set; }
+    }
+}

--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/Data/LiteDBContext.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/Data/LiteDBContext.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace AspNetCore.Identity.LiteDB.Data
 {
-    public class LiteDbContext
+    public class LiteDbContext : ILiteDbContext
     {
         private IHostingEnvironment HostingEnvironment { get; set; }
         public LiteDatabase LiteDatabase { get; set; }

--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbRoleStore.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbRoleStore.cs
@@ -14,7 +14,7 @@ namespace AspNetCore.Identity.LiteDB
         private readonly LiteCollection<TRole> _roles;
         private readonly LiteCollection<CancellationToken> _cancellationTokens;
 
-        public LiteDbRoleStore(LiteDbContext dbContext)
+        public LiteDbRoleStore(ILiteDbContext dbContext)
         {
             _roles = dbContext.LiteDatabase.GetCollection<TRole>("roles");
             _cancellationTokens = dbContext.LiteDatabase.GetCollection<CancellationToken>("cancellationtokens");

--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbUserStore.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbUserStore.cs
@@ -32,7 +32,7 @@ namespace AspNetCore.Identity.LiteDB
         private readonly LiteCollection<TUser> _users;
         private readonly LiteCollection<CancellationToken> _cancellationTokens;
 
-        public LiteDbUserStore(LiteDbContext dbContext)
+        public LiteDbUserStore(ILiteDbContext dbContext)
         {
             _users = dbContext.LiteDatabase.GetCollection<TUser>("users");
             _cancellationTokens = dbContext.LiteDatabase.GetCollection<CancellationToken>("cancellationtokens");


### PR DESCRIPTION
Using an interface for LiteDbContext adds flexibility by giving a chance to inject our own (for example, for changing the name or location of the database file, adding options to the connection string or even handling several databases).