### PR TITLE
Don't unintentionally close stdin on non-Windows.

### DIFF
--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbRoleStore.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbRoleStore.cs
@@ -164,7 +164,6 @@ namespace AspNetCore.Identity.LiteDB
       }
 
       private bool _disposed;
-      private readonly SafeHandle _handle = new SafeFileHandle(IntPtr.Zero, true);
 
       public void Dispose()
       {
@@ -175,11 +174,6 @@ namespace AspNetCore.Identity.LiteDB
       {
          if (_disposed)
             return;
-
-         if (disposing)
-         {
-            _handle.Dispose();
-         }
 
          _disposed = true;
       }

--- a/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbUserStore.cs
+++ b/AspNetCore.Identity.LiteDB/AspNetCore.Identity.LiteDB/LiteDbUserStore.cs
@@ -736,7 +736,6 @@ namespace AspNetCore.Identity.LiteDB
       }
 
       private bool _disposed;
-      private readonly SafeHandle _handle = new SafeFileHandle(IntPtr.Zero, true);
 
       public void Dispose()
       {
@@ -748,8 +747,6 @@ namespace AspNetCore.Identity.LiteDB
       {
          if (_disposed)
             return;
-
-         if (disposing) _handle.Dispose();
 
          _disposed = true;
       }


### PR DESCRIPTION
The SafeHandle that is used to implement IDisposable was copied from the .NET docs
and isn't needed. It leads to unintentionally closing stdin (file descriptor zero)
on non-Windows platforms, which causes to hard to diagnose issues in other code.

See https://github.com/dotnet/runtime/issues/64305, https://github.com/dotnet/runtime/issues/56750.